### PR TITLE
Create README that points to the new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Moved to https://github.com/rpi-ws281x/rpi-ws281x-rust


### PR DESCRIPTION
Google seems to point to this repo rather than the new one, so linking to it seems useful.